### PR TITLE
Update roles_common.js

### DIFF
--- a/roles/roles_common.js
+++ b/roles/roles_common.js
@@ -359,8 +359,8 @@ _.extend(Roles, {
       query.$or.push({roles: {$in: roles}})
     }
 
-    found = Meteor.users.findOne(query, {fields: {_id: 1}})
-    return found ? true : false
+    found = Meteor.users.find(query, {limit: 1, fields: {_id: 1}}).count()
+    return !!found
   },
 
   /**


### PR DESCRIPTION
userIsInRole DB query used is only checking IF the record exists, so replace the findOne(...) query (includes an un-needed fetch) with find(...,{limit:1}).count() which simply counts the matched objects directly from  the cursor and does not fetch it.
Then use `return !!found` to cast result to boolean true/false